### PR TITLE
fix(searxng): prefer self-hosted SEARXNG_INSTANCE over public instances

### DIFF
--- a/src/multi_search_api/providers/searxng.py
+++ b/src/multi_search_api/providers/searxng.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import random
 import time
 from datetime import datetime, timedelta
@@ -189,7 +190,12 @@ class SearXNGProvider(SearchProvider):
     def __init__(self, instance_url: str | None = None):
         self.instance_manager = SearXNGInstanceManager()
         self.instances = self.instance_manager.get_instances()
-        self.instance_url = instance_url or (
+        # Prefer a self-hosted instance (SEARXNG_INSTANCE env) over public ones:
+        # public instances give noisy/manipulated results. Keep publics as fallback.
+        env_instance = os.getenv("SEARXNG_INSTANCE")
+        if env_instance and env_instance not in self.instances:
+            self.instances.insert(0, env_instance)
+        self.instance_url = instance_url or env_instance or (
             self.instances[0] if self.instances else "https://searx.be"
         )
         self.current_instance_idx = 0

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -138,6 +138,19 @@ class TestSearXNGProvider:
         provider = SearXNGProvider(instance_url="https://custom.searx.com")
         assert provider.instance_url == "https://custom.searx.com"
 
+    def test_prefers_env_instance(self, monkeypatch):
+        """SEARXNG_INSTANCE env is preferred over public instances and kept in the pool."""
+        monkeypatch.setenv("SEARXNG_INSTANCE", "http://localhost:8888")
+        provider = SearXNGProvider()
+        assert provider.instance_url == "http://localhost:8888"
+        assert "http://localhost:8888" in provider.instances
+
+    def test_explicit_instance_overrides_env(self, monkeypatch):
+        """Explicit instance_url wins over SEARXNG_INSTANCE env."""
+        monkeypatch.setenv("SEARXNG_INSTANCE", "http://localhost:8888")
+        provider = SearXNGProvider(instance_url="https://custom.searx.com")
+        assert provider.instance_url == "https://custom.searx.com"
+
     @responses.activate
     def test_successful_search(self, mock_searxng_response):
         """Test successful search with SearXNG."""


### PR DESCRIPTION
## Probleem

`SmartSearchTool` construeert `SearXNGProvider()` zonder `instance_url`, waardoor de provider **altijd** publieke SearXNG-instances doorzocht (searx.space discovery + hardcoded fallbacks) en `SEARXNG_INSTANCE` volledig negeerde. Publieke instances geven ruis/SEO-gemanipuleerde resultaten — o.a. een niet-gerelateerde `forum.abv.bg` als top-hit voor een NL-organisatie ("Healfie"). Dat lekte door naar slechte link-repairs in de producer-pipeline.

De lokale self-hosted instance (`localhost:8888`) gaf voor dezelfde query wél het juiste resultaat (`healfie.nl` #1).

## Fix

`SearXNGProvider.__init__` honoreert nu `SEARXNG_INSTANCE`:
- env-instance wordt vooraan in de pool gezet en als default `instance_url` gebruikt
- publieke instances blijven als fallback (resilience bij lokale downtime)
- expliciete `instance_url`-arg wint nog steeds

## Tests

- `test_prefers_env_instance` — env preferred + in pool
- `test_explicit_instance_overrides_env` — expliciete arg wint
- 58/58 tests groen, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)